### PR TITLE
Add missing commit when loading updated constituent data

### DIFF
--- a/api/c10y/load_data.py
+++ b/api/c10y/load_data.py
@@ -62,6 +62,9 @@ def updated_constituents() -> Tuple[int, ConstituentList]:
                 # and error handling so we can weed out malformed data but still update other
                 # fields for the existing record.
                 print(f"Malformed: {constituent}\n{exc._message()}")
+
+        # Commit all updates that didn't cause IntegrityErrors or DataErrors
+        db_session.commit()
             
     return len(updates) - len(dupes), dupes   
 


### PR DESCRIPTION
Missing commit at the end of the `load_data.updated_constituents()` function prevented non-duplicate updated records from being added to the database.